### PR TITLE
Adicionada inserção de registros na EntityRevision

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -47,6 +47,9 @@ class Plugin extends \MapasCulturais\Plugin
 
     }
 
+    /**
+     * @throws \Exception
+     */
     function register()
     {
         $app = App::i();

--- a/assets/EditOpportunityType/css/main.css
+++ b/assets/EditOpportunityType/css/main.css
@@ -1,3 +1,7 @@
 .text-danger {
     color: #a94442;
 }
+
+#buttonEditType {
+    pointer-events: none;
+}

--- a/assets/EditOpportunityType/js/editOpportunityType.js
+++ b/assets/EditOpportunityType/js/editOpportunityType.js
@@ -1,9 +1,16 @@
 $(document).ready(() => {
-    $('#editTypeConfirm').on('click', () => {
+    const buttonEditType = document.getElementById('buttonEditType');
+
+    $('#buttonEditType').on('click', () => {
         $('#newOpportunityTypeShow').text($('#opportunityType option:selected')[0].innerText)
     })
 
     $('#dialog-confirm-change button.js-close').on('click', e => {
+        const buttonEditType = document.getElementById('buttonEditType')
+        buttonEditType.innerHTML = '<img src="' + MapasCulturais.spinnerURL + '" />'
+        buttonEditType.style.pointerEvents = 'none'
+        buttonEditType.classList.add('disabled')
+
         if(e.target.value) {
             const newOpportunityType = $('#opportunityType').val();
             const opportunityId = $('#opportunityId').val()
@@ -29,7 +36,8 @@ $(document).ready(() => {
     })
 
     $('#opportunityType').on('change', () => {
-        $('#editTypeConfirm').style.pointerEvents = 'initial'
+        buttonEditType.style.pointerEvents = 'initial'
+        buttonEditType.classList.remove('disabled')
     })
 
 })

--- a/layouts/parts/select-opportunity-type.php
+++ b/layouts/parts/select-opportunity-type.php
@@ -24,9 +24,9 @@ use MapasCulturais\i;
     </select>
     <input type="hidden" id="opportunityId" value=<?= $opportunityId ?>>
 
-    <a class="btn btn-primary js-open-dialog" href="javascript:void(0)"
+    <a class="btn btn-primary js-open-dialog disabled" href="javascript:void(0)"
        data-dialog-block="true" data-dialog="#dialog-confirm-change"
-       id="editTypeConfirm"
+       id="buttonEditType"
     >Confirmar alteração</a>
 
     <div id="dialog-confirm-change" class="js-dialog" style="z-index:1901">


### PR DESCRIPTION
- Implementado registro de alteração na EntityRevision (`@table=entity_revision`) e EntityRevisionData (`@table=entity_revision_data`).
- Implementado no botão de alteração o comportamento de não aceitar mais cliques e spinner de carregamento.

![image](https://github.com/secultce/plugin-EditOpportunityType/assets/42920699/cd91807c-0084-4c41-8487-4f384ece4b99)
